### PR TITLE
Fdroid support

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -59,6 +59,27 @@ android {
         }
     }
 
+    flavorDimensions "deploy"
+
+    productFlavors {
+        fdroid {
+            dimension "deploy"
+            signingConfig null
+        }
+        playstore {
+            dimension "deploy"
+            signingConfig signingConfigs.release
+        }
+    }
+
+    android.applicationVariants.all { variant ->
+        if (variant.flavorName == "fdroid") {
+            variant.outputs.all { output ->
+                output.outputFileName = "app-fdroid-release.apk"
+            }
+        }
+    }
+
     buildTypes {
         release {
             // Signing with the debug keys for now, so `flutter run --release` works.

--- a/com.amosgross.weight_track_app.yml
+++ b/com.amosgross.weight_track_app.yml
@@ -1,0 +1,40 @@
+AntiFeatures:
+  - HopeNot
+Categories:
+  - Sports & Health
+License: MIT
+AuthorName: Amos Groß
+AuthorEmail: email@amosgross.com
+AuthorWebSite: www.amosgross.com
+WebSite:
+SourceCode: https://github.com/grossamos/weight_track_app
+IssueTracker: https://github.com/grossamos/weight_track_app/issues
+Translation:
+Changelog:
+Donate:
+Bitcoin:
+
+AutoName: WeightTrackApp
+
+RepoType: git
+Repo: https://github.com/grossamos/weight_track_app
+
+Builds:
+  - versionName: 1.2.0
+    versionCode: 3
+    commit: v1.2.0+3
+    output: build/app/outputs/apk/fdroid/release/app-fdroid-release.apk
+    srclibs:
+      - flutter@2.2.3
+    rm:
+      - ios
+    build:
+      - $$flutter$$/bin/flutter config --no-analytics
+      - $$flutter$$/bin/flutter packages pub get
+      - $$flutter$$/bin/flutter build apk --flavor fdroid
+
+AutoUpdateMode: Version %v
+UpdateCheckMode: Tags
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+CurrentVersion: 1.2.0
+CurrentVersionCode: 3

--- a/fdroid-deploy-instructions.md
+++ b/fdroid-deploy-instructions.md
@@ -1,0 +1,12 @@
+Taken from https://gitlab.com/fdroid/fdroiddata/-/blob/master/CONTRIBUTING.md:
+
+1. Create account on [GitLab](https://about.gitlab.com/).
+2. Visit and fork the [fdroiddata](https://gitlab.com/fdroid/fdroiddata) repository.
+3. On local machine, clone your fork.
+4. Create and checkout a new branch. Name it `com.amosgross.weight_track_app`.
+5. Add the `com.amosgross.weight_track_app.yml` file.
+6. Commit and push to your upstream fork.
+7. Go to the `CI/CD` menu in the GitLab project of your fork.
+8. Check if the pipeline for your commit(s) succeed. If not, take a look into the logs and try to fix the error by editing the metadata file again.
+9. If everything went fine, you can create a new [merge request](https://gitlab.com/fdroid/fdroiddata/-/merge_requests) at the `fdroiddata` repository.
+10. Now wait for the packagers to pick up your Merge Request. Please keep track if they asked any questions and reply to them as soon as possible.


### PR DESCRIPTION
Hello! I took a stab at #5.

1. FDroid takes care of [signing](https://f-droid.org/en/docs/Signing_Process/) apps uploaded to their repository so the current application build needed updating to allow for a null `signingConfig`. Most examples online seemed to use the `flavor` pattern I incorporated.
2. To add an app to FDroid, they need a metadata file. I didn't populate the following optional fields because...well, I don't know you or your app :) I think you should follow up with a commit that populates or deletes the fields.
Refer to the [Build Spec](https://f-droid.org/en/docs/Build_Metadata_Reference/) for what these specifically require:
```yaml
AntiFeatures:
  - HopeNot
Translation:
Changelog:
Donate:
Bitcoin:
```
3. I didn't really feel like taking ownership of the GitLab fork that will maintain this application's relationship with FDroid, so I left a step-by-step digest of how to get there. 